### PR TITLE
Story-US-2026-1054, Story-US-2026-0987

### DIFF
--- a/src/api/home/content-types/home/schema.json
+++ b/src/api/home/content-types/home/schema.json
@@ -78,7 +78,7 @@
     },
     "testimonials": {
       "type": "component",
-      "repeatable": true,
+      "repeatable": false,
       "component": "shared.card",
       "pluginOptions": {
         "i18n": {

--- a/src/api/subtitle/content-types/subtitle/schema.json
+++ b/src/api/subtitle/content-types/subtitle/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "subtitles",
+  "info": {
+    "singularName": "subtitle",
+    "pluralName": "subtitles",
+    "displayName": "Subtitle",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "sourceId": {
+      "type": "string",
+      "unique": true,
+      "required": true
+    },
+    "subtitle": {
+      "type": "component",
+      "repeatable": true,
+      "component": "core.subtitle"
+    }
+  }
+}

--- a/src/api/subtitle/controllers/subtitle.ts
+++ b/src/api/subtitle/controllers/subtitle.ts
@@ -1,0 +1,7 @@
+/**
+ * subtitle controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::subtitle.subtitle');

--- a/src/api/subtitle/routes/subtitle.ts
+++ b/src/api/subtitle/routes/subtitle.ts
@@ -1,0 +1,7 @@
+/**
+ * subtitle router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::subtitle.subtitle');

--- a/src/api/subtitle/services/subtitle.ts
+++ b/src/api/subtitle/services/subtitle.ts
@@ -1,0 +1,7 @@
+/**
+ * subtitle service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::subtitle.subtitle');

--- a/src/components/core/image.json
+++ b/src/components/core/image.json
@@ -14,6 +14,9 @@
     },
     "svg": {
       "type": "string"
+    },
+    "sourceId": {
+      "type": "string"
     }
   }
 }

--- a/src/components/core/subtitle.json
+++ b/src/components/core/subtitle.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_core_subtitles",
+  "info": {
+    "displayName": "Subtitle",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "startTime": {
+      "type": "string"
+    },
+    "endTime": {
+      "type": "string"
+    },
+    "text": {
+      "type": "text"
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -140,6 +140,7 @@ export interface CoreImage extends Struct.ComponentSchema {
   attributes: {
     alternate: Schema.Attribute.String;
     source: Schema.Attribute.String;
+    sourceId: Schema.Attribute.String;
     svg: Schema.Attribute.String;
   };
 }
@@ -185,6 +186,19 @@ export interface CoreSeoIcons extends Struct.ComponentSchema {
     type: Schema.Attribute.String;
     url: Schema.Attribute.String;
     width: Schema.Attribute.BigInteger;
+  };
+}
+
+export interface CoreSubtitle extends Struct.ComponentSchema {
+  collectionName: 'components_core_subtitles';
+  info: {
+    description: '';
+    displayName: 'Subtitle';
+  };
+  attributes: {
+    endTime: Schema.Attribute.String;
+    startTime: Schema.Attribute.String;
+    text: Schema.Attribute.Text;
   };
 }
 
@@ -383,6 +397,7 @@ declare module '@strapi/strapi' {
       'core.options': CoreOptions;
       'core.plan': CorePlan;
       'core.seo-icons': CoreSeoIcons;
+      'core.subtitle': CoreSubtitle;
       'core.testimonial': CoreTestimonial;
       'shared.callout': SharedCallout;
       'shared.card': SharedCard;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1040,7 +1040,7 @@ export interface ApiHomeHome extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
-    testimonials: Schema.Attribute.Component<'shared.card', true> &
+    testimonials: Schema.Attribute.Component<'shared.card', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1706,6 +1706,42 @@ export interface ApiSolutionSolution extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiSubtitleSubtitle extends Struct.CollectionTypeSchema {
+  collectionName: 'subtitles';
+  info: {
+    description: '';
+    displayName: 'Subtitle';
+    pluralName: 'subtitles';
+    singularName: 'subtitle';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::subtitle.subtitle'
+    >;
+    publishedAt: Schema.Attribute.DateTime;
+    sourceId: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    subtitle: Schema.Attribute.Component<'core.subtitle', true>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiTermsAndConditionTermsAndCondition
   extends Struct.SingleTypeSchema {
   collectionName: 'terms_and_conditions';
@@ -2365,6 +2401,7 @@ declare module '@strapi/strapi' {
       'api::privacy-policy.privacy-policy': ApiPrivacyPolicyPrivacyPolicy;
       'api::product.product': ApiProductProduct;
       'api::solution.solution': ApiSolutionSolution;
+      'api::subtitle.subtitle': ApiSubtitleSubtitle;
       'api::terms-and-condition.terms-and-condition': ApiTermsAndConditionTermsAndCondition;
       'api::trend.trend': ApiTrendTrend;
       'plugin::content-releases.release': PluginContentReleasesRelease;


### PR DESCRIPTION
**Story-US-2026-1054 – [Home Page Revamp]**
- Updated the Home Page content type by changing the Testimonial section entry from repeatable to single.

**Story-US-2026-0987 – [Subtitle for Video]**
- Created new Subtitles collection content type.
- Added Subtitle component.
- Added sourceId field in the Product content type.